### PR TITLE
(fix): Reorder pathbuilder groups

### DIFF
--- a/src/wisski/api.py
+++ b/src/wisski/api.py
@@ -54,6 +54,19 @@ class Pathbuilder:
             int: The number of paths that were added
         """
         helper = paths.copy()
+
+        # reorder the paths by group status: two passes, first push all groups, then all other
+        groups = {}
+        other = {}
+        for k, v in helper.items():
+            if v['is_group']:
+                groups[k] = v
+            else:
+                other[k] = v
+
+        groups.update(dict(sorted(other.items(), reverse=True)))
+        helper = groups.copy()
+
         added = 0
         while helper:
             new_parent_ids = []


### PR DESCRIPTION
Due to how the path-tree is assembled, groups acting as parents must appear before their child fields in order for the hierarchy to be reconstructed correctly.

However, the pathbuilder XML does not guarantee this order, and groups may appear _after_ their children, thus breaking the tree.

Fix this by re-ordering the path list so that all groups appear at the front, followed by all non-groups (sort-of).